### PR TITLE
add autorestart parameter to mongod_instance

### DIFF
--- a/libraries/provider_mongod_instance.rb
+++ b/libraries/provider_mongod_instance.rb
@@ -56,7 +56,9 @@ class Chef
         config_file.run_action(:create)
 
         service.run_action(:enable)
-        service.run_action(:restart) if config_file.updated_by_last_action?
+        if new_resource.autorestart
+          service.run_action(:restart) if config_file.updated_by_last_action?
+        end
       end
     end
   end

--- a/libraries/resource_mongod_instance.rb
+++ b/libraries/resource_mongod_instance.rb
@@ -18,6 +18,7 @@ class Chef
         @config_cookbook = nil
         @logpath = '/var/log/mongodb'
         @dbpath = '/data/db'
+        @autorestart = false
         @options = {
           bind_ip: nil,
           port: 27017,
@@ -57,6 +58,10 @@ class Chef
 
       def config_cookbook(arg=nil)
         set_or_return(:config_cookbook, arg, :kind_of => [String])
+      end
+
+      def autorestart(arg=nil)
+        set_or_return(:autorestart, arg, :kind_of => [TrueClass, FalseClass])
       end
 
       def options(arg=nil)


### PR DESCRIPTION
When set to `true` the mongod instance will be restarted when chef updates it's configuration. Defaults to false. 
